### PR TITLE
Add trinity tool parser

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_trinity_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_trinity_tool_parser.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.entrypoints.openai.tool_parsers.utils import run_tool_extraction
+from vllm.entrypoints.openai.engine.protocol import FunctionCall
+from vllm.tokenizers import TokenizerLike, get_tokenizer
+from vllm.tool_parsers import ToolParser, ToolParserManager
+
+
+@pytest.fixture
+def trinity_tokenizer() -> TokenizerLike:
+    return get_tokenizer("arcee-ai/Trinity-Large-Preview")
+
+
+@pytest.fixture
+def trinity_parser(trinity_tokenizer: TokenizerLike) -> ToolParser:
+    return ToolParserManager.get_tool_parser("trinity")(trinity_tokenizer)
+
+
+THINK_TOOL_CALL_OUTPUT = """<think>internal reasoning</think>
+<tool_call>
+{"name": "final_answer", "arguments": {"trigger": true}}
+</tool_call>"""
+
+THINK_WRAPPED_TOOL_CALL_OUTPUT = """<think>internal reasoning
+<tool_call>
+{"name": "final_answer", "arguments": {"trigger": true}}
+</tool_call>
+more reasoning</think>"""
+
+THINK_NO_TOOL_CALL_OUTPUT = "<think>internal reasoning</think> done"
+
+FINAL_ANSWER_FUNCTION_CALL = FunctionCall(
+    name="final_answer",
+    arguments='{"trigger": true}',
+)
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+def test_trinity_parser_think_tool_call(
+    streaming: bool,
+    trinity_parser: ToolParser,
+) -> None:
+    content, tool_calls = run_tool_extraction(
+        trinity_parser, THINK_TOOL_CALL_OUTPUT, streaming=streaming
+    )
+
+    assert content == "internal reasoning"
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function == FINAL_ANSWER_FUNCTION_CALL
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+def test_trinity_parser_tool_call_within_think_tags(
+    streaming: bool,
+    trinity_parser: ToolParser,
+) -> None:
+    content, tool_calls = run_tool_extraction(
+        trinity_parser, THINK_WRAPPED_TOOL_CALL_OUTPUT, streaming=streaming
+    )
+
+    assert content == "internal reasoning"
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function == FINAL_ANSWER_FUNCTION_CALL
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+def test_trinity_parser_think_no_tool_call(
+    streaming: bool,
+    trinity_parser: ToolParser,
+) -> None:
+    content, tool_calls = run_tool_extraction(
+        trinity_parser, THINK_NO_TOOL_CALL_OUTPUT, streaming=streaming
+    )
+
+    assert content == "internal reasoning done"
+    assert tool_calls == []

--- a/tests/entrypoints/openai/tool_parsers/test_trinity_tool_parser_simple.py
+++ b/tests/entrypoints/openai/tool_parsers/test_trinity_tool_parser_simple.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Simple standalone tests for Trinity tool parser logic.
+These tests verify the core parsing without requiring the full vllm stack.
+"""
+
+import json
+import re
+
+import pytest
+
+
+class SimpleTrinityParser:
+    """Minimal recreation of Trinity parsing logic for testing."""
+
+    def __init__(self):
+        self.tool_call_start_token = "<tool_call>"
+        self.tool_call_end_token = "</tool_call>"
+        self.think_start_token = "<think>"
+        self.think_end_token = "</think>"
+        self.tool_call_regex = re.compile(
+            r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL
+        )
+
+    def _strip_think_tags(self, text: str) -> str:
+        return text.replace(self.think_start_token, "").replace(
+            self.think_end_token, ""
+        )
+
+    def extract_tool_calls(self, model_output: str) -> dict:
+        cleaned_output = self._strip_think_tags(model_output)
+
+        if self.tool_call_start_token not in cleaned_output:
+            return {
+                "tools_called": False,
+                "tool_calls": [],
+                "content": cleaned_output,
+            }
+
+        tool_call_json_list = self.tool_call_regex.findall(cleaned_output)
+        tool_calls = []
+        for tool_call_json in tool_call_json_list:
+            tool_call_dict = json.loads(tool_call_json)
+            args_str = json.dumps(
+                tool_call_dict.get("arguments", {}), ensure_ascii=False
+            )
+            tool_calls.append(
+                {
+                    "name": tool_call_dict.get("name", ""),
+                    "arguments": args_str,
+                }
+            )
+
+        content_idx = cleaned_output.find(self.tool_call_start_token)
+        content = cleaned_output[:content_idx].strip()
+
+        return {
+            "tools_called": len(tool_calls) > 0,
+            "tool_calls": tool_calls,
+            "content": content if content else None,
+        }
+
+
+@pytest.fixture
+def parser():
+    return SimpleTrinityParser()
+
+
+class TestTrinityParserLogic:
+    """Test the core Trinity parsing logic."""
+
+    def test_think_tags_followed_by_tool_call(self, parser):
+        """Think tags followed by tool call should extract both."""
+        output = """<think>internal reasoning</think>
+<tool_call>
+{"name": "final_answer", "arguments": {"trigger": true}}
+</tool_call>"""
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is True
+        assert result["content"] == "internal reasoning"
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["name"] == "final_answer"
+        assert result["tool_calls"][0]["arguments"] == '{"trigger": true}'
+
+    def test_tool_call_wrapped_inside_think_tags(self, parser):
+        """Tool call inside think tags should still be extracted."""
+        output = """<think>internal reasoning
+<tool_call>
+{"name": "final_answer", "arguments": {"trigger": true}}
+</tool_call>
+more reasoning</think>"""
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is True
+        assert result["content"] == "internal reasoning"
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["name"] == "final_answer"
+
+    def test_no_tool_call(self, parser):
+        """Output with only think tags and no tool call."""
+        output = "<think>internal reasoning</think> done"
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is False
+        assert result["tool_calls"] == []
+        assert "internal reasoning" in result["content"]
+        assert "done" in result["content"]
+
+    def test_multiple_tool_calls(self, parser):
+        """Multiple tool calls should all be extracted."""
+        output = """<think>thinking</think>
+<tool_call>
+{"name": "search", "arguments": {"query": "test"}}
+</tool_call>
+<tool_call>
+{"name": "calculate", "arguments": {"expr": "2+2"}}
+</tool_call>"""
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is True
+        assert len(result["tool_calls"]) == 2
+        assert result["tool_calls"][0]["name"] == "search"
+        assert result["tool_calls"][1]["name"] == "calculate"
+
+    def test_plain_tool_call_without_think_tags(self, parser):
+        """Tool call without think tags should work."""
+        output = """Some content
+<tool_call>
+{"name": "get_weather", "arguments": {"city": "NYC"}}
+</tool_call>"""
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is True
+        assert result["content"] == "Some content"
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["name"] == "get_weather"
+
+    def test_empty_arguments(self, parser):
+        """Tool call with empty arguments."""
+        output = """<tool_call>
+{"name": "no_args", "arguments": {}}
+</tool_call>"""
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is True
+        assert result["tool_calls"][0]["name"] == "no_args"
+        assert result["tool_calls"][0]["arguments"] == "{}"
+
+    def test_nested_json_arguments(self, parser):
+        """Tool call with nested JSON arguments."""
+        output = """<tool_call>
+{"name": "complex", "arguments": {"nested": {"a": 1, "b": [1, 2, 3]}}}
+</tool_call>"""
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is True
+        assert result["tool_calls"][0]["name"] == "complex"
+        args = json.loads(result["tool_calls"][0]["arguments"])
+        assert args["nested"]["a"] == 1
+        assert args["nested"]["b"] == [1, 2, 3]
+
+    def test_plain_text_no_tags(self, parser):
+        """Plain text with no tags at all."""
+        output = "Just some regular text without any special tags."
+
+        result = parser.extract_tool_calls(output)
+
+        assert result["tools_called"] is False
+        assert result["content"] == output
+        assert result["tool_calls"] == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/kernels/utils.py
+++ b/tests/kernels/utils.py
@@ -609,7 +609,7 @@ def _num_tokens_to_min_blocks(num_tokens: int, block_size: int) -> int:
     Compute the minimum number of blocks required to hold num_tokens tokens,
     given block_size
     """
-    return (num_tokens + block_size) // block_size
+    return (num_tokens + block_size - 1) // block_size
 
 
 def make_empty_slot_mapping_tensor(device: torch.device | str):
@@ -694,7 +694,7 @@ def make_block_tables_slot_mapping(
     For a sequence with num_tokens tokens the minimum number
     of required KV cache blocks is
 
-    num_blocks = (num_tokens + block_size) // block_size
+    num_blocks = (num_tokens + block_size - 1) // block_size
 
     Then the minimum KV cache size in blocks is
 

--- a/vllm/distributed/device_communicators/xpu_communicator.py
+++ b/vllm/distributed/device_communicators/xpu_communicator.py
@@ -23,22 +23,145 @@ class XpuCommunicator(DeviceCommunicatorBase):
     ):
         super().__init__(cpu_group, device, device_group, unique_name)
         if self.use_all2all:
-            if self.all2all_backend != "naive":  # type: ignore[has-type]
-                logger.warning(
-                    "`%s` all2all manager is not supported on XPU. "
-                    "Falling back to `naive` all2all manager for XPU.",
-                    self.all2all_backend,  # type: ignore[has-type]
-                )
-                self.all2all_backend = "naive"
             if self.all2all_backend == "naive":
                 from .all2all import NaiveAll2AllManager
 
                 self.all2all_manager = NaiveAll2AllManager(self.cpu_group)
                 logger.info("Using naive all2all manager.")
 
+            elif self.all2all_backend == "allgather_reducescatter":
+                from .all2all import AgRsAll2AllManager
+
+                self.all2all_manager = AgRsAll2AllManager(self.cpu_group)
+                logger.info("Using AgRs manager on XPU device.")
+
+            else:  # type: ignore[has-type]
+                logger.warning(
+                    "`%s` all2all manager is not supported on XPU. "
+                    "Falling back to AgRs manager for XPU, "
+                    "which is the Default backend",
+                    self.all2all_backend,  # type: ignore[has-type]
+                )
+                from .all2all import AgRsAll2AllManager
+
+                self.all2all_manager = AgRsAll2AllManager(self.cpu_group)
+                logger.info("Using AgRs manager on XPU device.")
+
     def all_reduce(self, input_) -> torch.Tensor:
         dist.all_reduce(input_, group=self.device_group)
         return input_
+
+    def reduce_scatter(self, input_: torch.Tensor, dim: int = -1):
+        world_size = self.world_size
+
+        if dim < 0:
+            # Convert negative dim to positive.
+            dim += input_.dim()
+
+        # Note: This will produce an incorrect answer if we don't make
+        # the input_tensor contiguous. Possible bug in reduce_scatter_tensor?
+        input_tensor = input_.movedim(0, dim).contiguous()
+
+        assert input_tensor.shape[0] % world_size == 0
+        chunk_size = input_tensor.shape[0] // world_size
+        output_shape = (chunk_size,) + input_tensor.shape[1:]
+
+        output = torch.empty(
+            output_shape, dtype=input_tensor.dtype, device=input_tensor.device
+        )
+
+        dist.reduce_scatter_tensor(output, input_tensor)
+
+        # Reshape before returning
+        return output.movedim(0, dim).contiguous()
+
+    def reduce_scatterv(
+        self, input_: torch.Tensor, dim: int = -1, sizes: list[int] | None = None
+    ):
+        world_size = self.world_size
+
+        if dim < 0:
+            # Convert negative dim to positive.
+            dim += input_.dim()
+
+        # Note: This will produce an incorrect answer if we don't make
+        # the input_tensor contiguous. Possible bug in reduce_scatter_tensor?
+        input_tensor = input_.movedim(0, dim).contiguous()
+
+        if sizes is not None:
+            assert len(sizes) == world_size
+            assert input_tensor.shape[0] == sum(sizes)
+            chunk_size = sizes[self.rank_in_group]
+        else:
+            assert input_tensor.shape[0] % world_size == 0
+            chunk_size = input_tensor.shape[0] // world_size
+        output_shape = (chunk_size,) + input_tensor.shape[1:]
+
+        output = torch.empty(
+            output_shape, dtype=input_tensor.dtype, device=input_tensor.device
+        )
+        if sizes is not None and sizes.count(sizes[0]) != len(sizes):
+            # if inputs shape in different ranks is not the same using reduce_scatter
+            input_splits = list(input_tensor.split(sizes, dim=0))
+            dist.reduce_scatter(output, input_splits)
+        else:
+            dist.reduce_scatter_tensor(output, input_tensor)
+        # Reshape before returning
+        return output.movedim(0, dim).contiguous()
+
+    def all_gatherv(
+        self,
+        input_: torch.Tensor | list[torch.Tensor],
+        dim: int = 0,
+        sizes: list[int] | None = None,
+    ):
+        if dim != 0:
+            raise NotImplementedError("only dim 0 all-gatherv is supported")
+        world_size = self.world_size
+
+        # 'sizes' is not needed if all inputs in the same group have the same
+        # shape
+        if sizes is not None and all(s == sizes[0] for s in sizes):
+            sizes = None
+
+        def _all_gather_single(input_: torch.Tensor, sizes: list[int] | None = None):
+            input_size = input_.size()
+            if sizes is not None:
+                assert len(sizes) == world_size
+                assert input_.shape[dim] == sizes[self.rank_in_group], (
+                    f"{input_.shape[dim]} != {sizes[self.rank_in_group]}"
+                )
+                output_size = (sum(sizes),) + input_size[1:]
+            else:
+                output_size = (input_size[0] * world_size,) + input_size[1:]
+            # Allocate output tensor.
+            output_tensor = torch.empty(
+                output_size, dtype=input_.dtype, device=input_.device
+            )
+
+            if sizes is not None:
+                all_gather_list = []
+                for size in sizes:
+                    all_gather_list.append(
+                        torch.empty(
+                            (size,) + input_.shape[1:],
+                            dtype=input_.dtype,
+                            device=input_.device,
+                        )
+                    )
+                dist.all_gather(all_gather_list, input_)
+                output_tensor = torch.cat(all_gather_list, dim=0)
+            else:
+                dist.all_gather([output_tensor], input_)
+            return output_tensor
+
+        if isinstance(input_, torch.Tensor):
+            return _all_gather_single(input_, sizes)
+
+        output_list = []
+        for inp in input_:
+            output_list.append(_all_gather_single(inp, sizes=sizes))
+        return output_list
 
     def gather(
         self, input_: torch.Tensor, dst: int = 0, dim: int = -1

--- a/vllm/model_executor/models/aria.py
+++ b/vllm/model_executor/models/aria.py
@@ -621,14 +621,8 @@ class AriaForConditionalGeneration(nn.Module, SupportsMultiModal):
         inputs_embeds: torch.Tensor | None = None,
         **kwargs: object,
     ) -> torch.Tensor | IntermediateTensors:
-        if inputs_embeds is None:
-            multimodal_embeddings = self.embed_multimodal(**kwargs)
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                multimodal_embeddings,
-                is_multimodal=input_ids == self.config.image_token_index,
-            )
-            input_ids = None
+        if intermediate_tensors is not None:
+            inputs_embeds = None
 
         hidden_states = self.language_model(
             input_ids,

--- a/vllm/model_executor/models/dots_ocr.py
+++ b/vllm/model_executor/models/dots_ocr.py
@@ -791,14 +791,6 @@ class DotsOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA
     ) -> torch.Tensor | IntermediateTensors:
         if intermediate_tensors is not None:
             inputs_embeds = None
-        elif inputs_embeds is None:
-            vision_embeddings = self.embed_multimodal(**kwargs)
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                vision_embeddings,
-                is_multimodal=input_ids == self.config.image_token_id,
-            )
-            input_ids = None
 
         hidden_states = self.language_model(
             input_ids=input_ids,

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -71,8 +71,6 @@ def _require_is_multimodal(is_multimodal: Tensor | None) -> Tensor:
 
 
 class LMMissingLayer(nn.Module):
-    packed_modules_mapping: dict[str, list[str]] = {}
-
     def make_empty_intermediate_tensors(self, *args, **kwargs):
         raise RuntimeError("This module should not be called in MM encoder-only mode")
 
@@ -81,8 +79,6 @@ class LMMissingLayer(nn.Module):
 
 
 class TowerMissingLayer(nn.Module):
-    packed_modules_mapping: dict[str, list[str]] = {}
-
     def __init__(self, modalities: set[str] | str) -> None:
         if isinstance(modalities, str):
             modalities = {modalities}
@@ -92,7 +88,10 @@ class TowerMissingLayer(nn.Module):
         self.modalities = modalities
 
     def __call__(self, *args, **kwargs):
-        raise RuntimeError(f"The following modalities are disabled: {self.modalities}")
+        raise RuntimeError(
+            f"This module should not be called when the following "
+            f"modalities are disabled: {self.modalities}"
+        )
 
 
 @contextmanager

--- a/vllm/model_executor/models/interns1.py
+++ b/vllm/model_executor/models/interns1.py
@@ -789,7 +789,6 @@ class InternS1ForConditionalGeneration(
         **kwargs: object,
     ) -> IntermediateTensors:
         if intermediate_tensors is not None:
-            input_ids = None
             inputs_embeds = None
 
         forward_kwargs = {

--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -1379,7 +1379,6 @@ class InternVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA)
         **kwargs: object,
     ) -> IntermediateTensors:
         if intermediate_tensors is not None:
-            input_ids = None
             inputs_embeds = None
 
         forward_kwargs = {

--- a/vllm/model_executor/models/minicpmo.py
+++ b/vllm/model_executor/models/minicpmo.py
@@ -553,9 +553,11 @@ class MiniCPMO(MiniCPMV2_6):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
-        self.apm = self.init_audio_module(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "apm")
-        )
+
+        with self._mark_tower_model(vllm_config, "audio"):
+            self.apm = self.init_audio_module(
+                vllm_config=vllm_config, prefix=maybe_prefix(prefix, "apm")
+            )
 
     def init_audio_module(self, *, vllm_config: VllmConfig, prefix: str = ""):
         # Do not use parameters temporarily

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1028,25 +1028,27 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         self.multimodal_config = multimodal_config
 
         self.version = get_version_by_config(self.config)
-        self.llm = self.init_llm(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "llm")
-        )
-        self.vpm = self.init_vision_module(
-            config, quant_config, prefix=maybe_prefix(prefix, "vpm")
-        )
-        self.vision_dim = (
-            self.vpm.embed_dim
-            if self.version == (2, 0)
-            else self.vpm.embeddings.embed_dim
-        )
-        self.embed_dim = self.config.hidden_size
 
-        self.resampler = self.init_resampler(
-            self.embed_dim,
-            self.vision_dim,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "resampler"),
-        )
+        with self._mark_language_model(vllm_config):
+            self.llm = self.init_llm(
+                vllm_config=vllm_config, prefix=maybe_prefix(prefix, "llm")
+            )
+
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.vpm = vpm = self.init_vision_module(
+                config, quant_config, prefix=maybe_prefix(prefix, "vpm")
+            )
+            self.vision_dim = (
+                vpm.embed_dim if self.version == (2, 0) else vpm.embeddings.embed_dim
+            )
+            self.embed_dim = self.config.hidden_size
+
+            self.resampler = self.init_resampler(
+                self.embed_dim,
+                self.vision_dim,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "resampler"),
+            )
 
         self.make_empty_intermediate_tensors = self.llm.make_empty_intermediate_tensors
 
@@ -1133,9 +1135,6 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
                 multimodal_embeddings += tuple(video_embeddings)
 
         return multimodal_embeddings
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.llm
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
         modalities = self._parse_and_validate_multimodal_inputs(**kwargs)

--- a/vllm/model_executor/models/minimax_vl_01.py
+++ b/vllm/model_executor/models/minimax_vl_01.py
@@ -201,28 +201,33 @@ class MiniMaxVL01ForConditionalGeneration(nn.Module, SupportsMultiModal, Support
         self.config = config
         self.multimodal_config = multimodal_config
 
-        # TODO: Optionally initializes this for supporting embeddings.
-        self.vision_tower = init_vision_tower_for_llava(
-            config,
-            quant_config=quant_config,
-            multimodal_config=multimodal_config,
-            require_post_norm=False,
-            prefix=maybe_prefix(prefix, "vision_tower"),
-        )
-        self.multi_modal_projector = MiniMaxVL01MultiModalProjector(
-            vision_hidden_size=config.vision_config.hidden_size,
-            text_hidden_size=config.text_config.hidden_size,
-            projector_hidden_act=config.projector_hidden_act,
-            multimodal_projector_bias=True,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "multi_modal_projector"),
-        )
-        self.image_newline = nn.Parameter(torch.empty(config.text_config.hidden_size))
-        self.language_model = init_vllm_registered_model(
-            vllm_config=vllm_config,
-            hf_config=config.text_config,
-            prefix=maybe_prefix(prefix, "language_model"),
-        )
+        with self._mark_tower_model(vllm_config, "image"):
+            self.vision_tower = init_vision_tower_for_llava(
+                config,
+                quant_config=quant_config,
+                multimodal_config=multimodal_config,
+                require_post_norm=False,
+                prefix=maybe_prefix(prefix, "vision_tower"),
+            )
+            self.multi_modal_projector = MiniMaxVL01MultiModalProjector(
+                vision_hidden_size=config.vision_config.hidden_size,
+                text_hidden_size=config.text_config.hidden_size,
+                projector_hidden_act=config.projector_hidden_act,
+                multimodal_projector_bias=True,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "multi_modal_projector"),
+            )
+            self.image_newline = nn.Parameter(
+                torch.empty(config.text_config.hidden_size)
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                hf_config=config.text_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+
         self.vision_feature_layer = config.vision_feature_layer
         self.vocab_size = config.text_config.vocab_size
         self.pad_token_id = -1
@@ -232,9 +237,6 @@ class MiniMaxVL01ForConditionalGeneration(nn.Module, SupportsMultiModal, Support
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors
         )
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.language_model
 
     def _image_pixels_to_features(
         self,
@@ -302,8 +304,6 @@ class MiniMaxVL01ForConditionalGeneration(nn.Module, SupportsMultiModal, Support
         self,
         inputs: MiniMaxVL01ImagePixelInputs,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
-        assert self.vision_tower is not None
-
         pixel_values = inputs["pixel_values"]
         return self._image_pixels_to_features(self.vision_tower, pixel_values)
 
@@ -314,7 +314,6 @@ class MiniMaxVL01ForConditionalGeneration(nn.Module, SupportsMultiModal, Support
         if image_input["type"] == "image_embeds":
             return image_input["data"]
 
-        assert self.vision_tower is not None
         image_features = self._process_image_pixels(image_input)
 
         if isinstance(image_features, torch.Tensor):
@@ -369,14 +368,6 @@ class MiniMaxVL01ForConditionalGeneration(nn.Module, SupportsMultiModal, Support
     ) -> torch.Tensor | IntermediateTensors:
         if intermediate_tensors is not None:
             inputs_embeds = None
-        elif inputs_embeds is None:
-            vision_embeddings = self.embed_multimodal(**kwargs)
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                vision_embeddings,
-                is_multimodal=input_ids == self.config.image_token_index,
-            )
-            input_ids = None
 
         hidden_states = self.language_model.model(
             input_ids, positions, intermediate_tensors, inputs_embeds=inputs_embeds

--- a/vllm/model_executor/models/molmo.py
+++ b/vllm/model_executor/models/molmo.py
@@ -1441,15 +1441,20 @@ class MolmoForCausalLM(
         self.multimodal_config = multimodal_config
 
         vision_config = VisionBackboneConfig()
-        self.vision_backbone = MolmoVisionBackbone(
-            config,
-            vision_config,
-            quant_config,
-            prefix=maybe_prefix(prefix, "vision_backbone"),
-        )
-        self.model = MolmoModel(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
-        )
+
+        with self._mark_tower_model(vllm_config, "image"):
+            self.vision_backbone = MolmoVisionBackbone(
+                config,
+                vision_config,
+                quant_config,
+                prefix=maybe_prefix(prefix, "vision_backbone"),
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.model = MolmoModel(
+                vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+            )
+
         self.img_patch_id = None
 
         if self.config.weight_tying:
@@ -1524,9 +1529,6 @@ class MolmoForCausalLM(
             order = torch.argsort(valid_img_idx)
             results.append(feats[is_valid][order])
         return results
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.model
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/vllm/model_executor/models/molmo2.py
+++ b/vllm/model_executor/models/molmo2.py
@@ -2514,16 +2514,19 @@ class Molmo2ForConditionalGeneration(
             kwargs[field.name] = getattr(config.adapter_config, field.name)
         adapter_config = AdapterConfig(**kwargs)
 
-        self.vision_backbone = Molmo2VisionBackbone(
-            vit_config,
-            adapter_config,
-            quant_config,
-            prefix=maybe_prefix(prefix, "vision_backbone"),
-        )
-        self.model = Molmo2TextModel(
-            vllm_config=vllm_config,
-            prefix=maybe_prefix(prefix, "model"),
-        )
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.vision_backbone = Molmo2VisionBackbone(
+                vit_config,
+                adapter_config,
+                quant_config,
+                prefix=maybe_prefix(prefix, "vision_backbone"),
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.model = Molmo2TextModel(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "model"),
+            )
 
         self.img_patch_id = config.image_patch_id
 
@@ -2686,9 +2689,6 @@ class Molmo2ForConditionalGeneration(
             out_features[is_image_patch] = image_features_i
             out.append(out_features)
         return tuple(out)
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.model
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | None:
         modalities = self._parse_and_validate_multimodal_inputs(**kwargs)

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -820,16 +820,18 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
 
-        self.encoder = RadioWithNeck(
-            config=config, quant_config=quant_config, prefix=f"{prefix}.encoder"
-        )
+        with self._mark_tower_model(vllm_config, "image"):
+            self.encoder = RadioWithNeck(
+                config=config, quant_config=quant_config, prefix=f"{prefix}.encoder"
+            )
 
-        self.decoder = MBartDecoderNoPos(
-            config.decoder,
-            cache_config=cache_config,
-            quant_config=quant_config,
-            prefix=f"{prefix}.decoder",
-        )
+        with self._mark_language_model(vllm_config):
+            self.decoder = MBartDecoderNoPos(
+                config.decoder,
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.decoder",
+            )
 
         self.vocab_size = config.decoder.vocab_size
         self.lm_head = ParallelLMHead(
@@ -882,9 +884,6 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
         dtype = next(self.encoder.parameters()).dtype
         pixel_values = pixel_values.to(dtype)
         return self.encoder(pixel_values)
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.decoder
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings | None:
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/vllm/model_executor/models/nemotron_vl.py
+++ b/vllm/model_executor/models/nemotron_vl.py
@@ -385,20 +385,20 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
         self.downsample_ratio = config.downsample_ratio
         self.ps_version = config.ps_version
 
-        self.llm_arch_name = config.text_config.architectures[0]
-        self.vision_model = self._init_vision_model(
-            config,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "vision_model"),
-        )
+        with self._mark_tower_model(vllm_config, "image"):
+            self.vision_model = self._init_vision_model(
+                config,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "vision_model"),
+            )
+            self.mlp1 = self._init_mlp1(config)
 
-        self.language_model = init_vllm_registered_model(
-            vllm_config=vllm_config,
-            hf_config=config.text_config,
-            prefix=maybe_prefix(prefix, "language_model"),
-        )
-
-        self.mlp1 = self._init_mlp1(config)
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                hf_config=config.text_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
 
         self.img_context_token_id = None
 
@@ -520,8 +520,6 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
         if image_input["type"] == "image_embeds":
             return image_input["data"]
 
-        assert self.vision_model is not None
-
         image_embeds = self.extract_feature(image_input["pixel_values_flat"])
 
         num_patches = image_input["num_patches"]
@@ -555,9 +553,6 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
 
     def _set_visual_token_mask(self, input_ids: torch.Tensor) -> None:
         self.visual_token_mask = None
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.language_model
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
         modalities = self._parse_and_validate_multimodal_inputs(**kwargs)
@@ -609,7 +604,6 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
         **kwargs: object,
     ) -> IntermediateTensors:
         if intermediate_tensors is not None:
-            input_ids = None
             inputs_embeds = None
 
         forward_kwargs = {

--- a/vllm/model_executor/models/ovis.py
+++ b/vllm/model_executor/models/ovis.py
@@ -417,7 +417,7 @@ class Ovis(nn.Module, SupportsMultiModal, SupportsPP):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("image"):
-            return "<image>"
+            return IMAGE_TOKEN
 
         raise ValueError("Only image modality is supported")
 
@@ -427,20 +427,22 @@ class Ovis(nn.Module, SupportsMultiModal, SupportsPP):
         quant_config = vllm_config.quant_config
 
         self.config: PretrainedConfig = config
-        self.llm = init_vllm_registered_model(
-            vllm_config=vllm_config.with_hf_config(config.get_text_config()),
-            prefix=maybe_prefix(prefix, "llm"),
-        )
 
-        self.visual_tokenizer = VisualTokenizer(
-            config=config.visual_tokenizer_config,
-            quant_config=quant_config,
-            prefix=f"{prefix}.visual_tokenizer",
-        )
+        with self._mark_language_model(vllm_config):
+            self.llm = init_vllm_registered_model(
+                vllm_config=vllm_config.with_hf_config(config.get_text_config()),
+                prefix=maybe_prefix(prefix, "llm"),
+            )
 
-        self.vte = VisualEmbedding(
-            self.config.visual_tokenizer_config.vocab_size, self.config.hidden_size
-        )
+        with self._mark_tower_model(vllm_config, "image"):
+            self.visual_tokenizer = VisualTokenizer(
+                config=config.visual_tokenizer_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.visual_tokenizer",
+            )
+            self.vte = VisualEmbedding(
+                self.config.visual_tokenizer_config.vocab_size, self.config.hidden_size
+            )
 
         text_model_type = self.config.get_text_config().model_type
         self.image_pad_token_id = IMAGE_PAD_TOKEN_ID_MAP[text_model_type]
@@ -546,12 +548,8 @@ class Ovis(nn.Module, SupportsMultiModal, SupportsPP):
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
-        logits = self.llm.compute_logits(hidden_states)
-        return logits
+        return self.llm.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.llm

--- a/vllm/model_executor/models/ovis2_5.py
+++ b/vllm/model_executor/models/ovis2_5.py
@@ -451,6 +451,15 @@ class Ovis2_5MultiModalProcessor(BaseMultiModalProcessor[Ovis2_5ProcessingInfo])
     dummy_inputs=Ovis2_5DummyInputsBuilder,
 )
 class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return IMAGE_TOKEN
+        if modality.startswith("video"):
+            return VIDEO_TOKEN
+
+        raise ValueError("Only image or video modality is supported")
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -458,20 +467,22 @@ class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
         multimodal_config = vllm_config.model_config.multimodal_config
 
         self.config: PretrainedConfig = config
-        self.llm = init_vllm_registered_model(
-            vllm_config=vllm_config.with_hf_config(config.text_config),
-            prefix=maybe_prefix(prefix, "llm"),
-        )
 
-        self.visual_tokenizer = VisualTokenizer(
-            config=config.vit_config,
-            visual_vocab_size=config.visual_vocab_size,
-            multimodal_config=multimodal_config,
-            quant_config=quant_config,
-            prefix=f"{prefix}.visual_tokenizer",
-        )
+        with self._mark_language_model(vllm_config):
+            self.llm = init_vllm_registered_model(
+                vllm_config=vllm_config.with_hf_config(config.text_config),
+                prefix=maybe_prefix(prefix, "llm"),
+            )
 
-        self.vte = VisualEmbedding(config.visual_vocab_size, config.hidden_size)
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.visual_tokenizer = VisualTokenizer(
+                config=config.vit_config,
+                visual_vocab_size=config.visual_vocab_size,
+                multimodal_config=multimodal_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.visual_tokenizer",
+            )
+            self.vte = VisualEmbedding(config.visual_vocab_size, config.hidden_size)
 
         text_model_type = self.config.get_text_config().model_type
         self.image_pad_token_id = IMAGE_PAD_TOKEN_ID_MAP[text_model_type]
@@ -650,12 +661,8 @@ class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
-        logits = self.llm.compute_logits(hidden_states)
-        return logits
+        return self.llm.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.llm

--- a/vllm/model_executor/models/paligemma.py
+++ b/vllm/model_executor/models/paligemma.py
@@ -295,30 +295,32 @@ class PaliGemmaForConditionalGeneration(
         multimodal_config = vllm_config.model_config.multimodal_config
         self.config = config
         self.multimodal_config = multimodal_config
-
-        self.vision_tower = SiglipVisionModel(
-            config.vision_config,
-            quant_config,
-            prefix=maybe_prefix(prefix, "vision_tower"),
-        )
-        self.multi_modal_projector = PaliGemmaMultiModalProjector(
-            vision_hidden_size=config.vision_config.hidden_size,
-            projection_dim=config.vision_config.projection_dim,
-        )
-
         self.quant_config = quant_config
+
+        with self._mark_tower_model(vllm_config, "image"):
+            self.vision_tower = SiglipVisionModel(
+                config.vision_config,
+                quant_config,
+                prefix=maybe_prefix(prefix, "vision_tower"),
+            )
+            self.multi_modal_projector = PaliGemmaMultiModalProjector(
+                vision_hidden_size=config.vision_config.hidden_size,
+                projection_dim=config.vision_config.projection_dim,
+            )
 
         if config.text_config.model_type == "gemma":
             config.text_config.architectures = ["GemmaForCausalLM"]
         else:
             config.text_config.architectures = ["Gemma2ForCausalLM"]
-        self.language_model = init_vllm_registered_model(
-            vllm_config=vllm_config,
-            hf_config=config.text_config,
-            prefix=maybe_prefix(prefix, "language_model"),
-        )
-        logit_scale = getattr(config, "logit_scale", 1.0)
-        self.language_model.logits_processor.scale *= logit_scale
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                hf_config=config.text_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+            logit_scale = getattr(config, "logit_scale", 1.0)
+            language_model.logits_processor.scale *= logit_scale
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors
@@ -367,7 +369,6 @@ class PaliGemmaForConditionalGeneration(
         if image_input["type"] == "image_embeds":
             return image_input["data"]
 
-        assert self.vision_tower is not None
         pixel_values = image_input["data"]
         image_features = self._image_pixels_to_features(
             self.vision_tower,
@@ -375,9 +376,6 @@ class PaliGemmaForConditionalGeneration(
         )
 
         return self.multi_modal_projector(image_features)
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.language_model
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/vllm/model_executor/models/phi4mm.py
+++ b/vllm/model_executor/models/phi4mm.py
@@ -1027,12 +1027,13 @@ class Phi4MMForCausalLM(nn.Module, SupportsLoRA, SupportsMultiModal):
         # Tensor/Pipeline parallel not supported for now.
         assert get_pp_group().world_size == 1, "pipeline parallel is not supported"
 
-        self.vision_encoder = Phi4MMImageEncoder(
-            config,
-            quant_config,
-            prefix="model.vision_embed_tokens",
-            model_dir=config._name_or_path,
-        )
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.vision_encoder = Phi4MMImageEncoder(
+                config,
+                quant_config,
+                prefix="model.vision_embed_tokens",
+                model_dir=config._name_or_path,
+            )
 
         if isinstance(config.embd_layer["audio_embd_layer"], dict):
             embedding_config = {
@@ -1044,10 +1045,13 @@ class Phi4MMForCausalLM(nn.Module, SupportsLoRA, SupportsMultiModal):
                 "embedding_cls": self.config.embd_layer["embedding_cls"]
             }
 
-        self.embed_tokens_extend = AudioEmbedding(config, **embedding_config)
-        self.model = LlamaModel(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
-        )
+        with self._mark_tower_model(vllm_config, "audio"):
+            self.embed_tokens_extend = AudioEmbedding(config, **embedding_config)
+
+        with self._mark_language_model(vllm_config):
+            self.model = LlamaModel(
+                vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+            )
 
         self.lm_head = ParallelLMHead(
             config.vocab_size,
@@ -1245,6 +1249,3 @@ class Phi4MMForCausalLM(nn.Module, SupportsLoRA, SupportsMultiModal):
             connector=["audio_projection_for_vision", "audio_projection"],
             tower_model=["vision_encoder", "embed_tokens_extend"],
         )
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.model

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -453,15 +453,15 @@ class Qwen3VLMoeForConditionalGeneration(
                 ]
 
         with self._mark_language_model(vllm_config):
-            self.language_model = Qwen3MoeLLMForCausalLM(
+            self.language_model = language_model = Qwen3MoeLLMForCausalLM(
                 vllm_config=vllm_config, prefix=maybe_prefix(prefix, "language_model")
             )
 
-        # Whether to include the gate_up_proj mapping is determined by
-        # the language model.
-        self.packed_modules_mapping = (
-            self.packed_modules_mapping | self.language_model.packed_modules_mapping
-        )
+            # Whether to include the gate_up_proj mapping is determined by
+            # the language model.
+            self.packed_modules_mapping = (
+                self.packed_modules_mapping | language_model.packed_modules_mapping
+            )
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors

--- a/vllm/model_executor/models/skyworkr1v.py
+++ b/vllm/model_executor/models/skyworkr1v.py
@@ -908,7 +908,6 @@ class SkyworkR1VChatModel(nn.Module, SupportsMultiModal, SupportsPP):
         **kwargs: object,
     ) -> IntermediateTensors:
         if intermediate_tensors is not None:
-            input_ids = None
             inputs_embeds = None
 
         forward_kwargs = {

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -1104,14 +1104,6 @@ class Step3VLForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP)
     ) -> torch.Tensor | IntermediateTensors:
         if intermediate_tensors is not None:
             inputs_embeds = None
-        elif inputs_embeds is None:
-            vision_embeddings = self.embed_multimodal(**kwargs)
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                vision_embeddings,
-                is_multimodal=input_ids == self.config.image_token_id,
-            )
-            input_ids = None
 
         hidden_states = self.language_model(
             input_ids, positions, intermediate_tensors, inputs_embeds=inputs_embeds

--- a/vllm/model_executor/models/tarsier.py
+++ b/vllm/model_executor/models/tarsier.py
@@ -597,14 +597,7 @@ class TarsierForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP)
     ) -> torch.Tensor | IntermediateTensors:
         if intermediate_tensors is not None:
             inputs_embeds = None
-        elif inputs_embeds is None:
-            vision_embeddings = self.embed_multimodal(**kwargs)
-            inputs_embeds = self.embed_input_ids(
-                input_ids,
-                vision_embeddings,
-                is_multimodal=input_ids == self.config.image_token_index,
-            )
-            input_ids = None
+
         hidden_states = self.language_model.model(
             input_ids=input_ids,
             positions=positions,

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -134,6 +134,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "step3_tool_parser",
         "Step3ToolParser",
     ),
+    "trinity": (
+        "trinity_tool_parser",
+        "TrinityToolParser",
+    ),
     "xlam": (
         "xlam_tool_parser",
         "xLAMToolParser",

--- a/vllm/tool_parsers/trinity_tool_parser.py
+++ b/vllm/tool_parsers/trinity_tool_parser.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from collections.abc import Sequence
+
+import regex as re
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
+
+logger = init_logger(__name__)
+
+
+class TrinityToolParser(ToolParser):
+    """
+    Tool parser for Trinity models using Qwen-style tool call format:
+
+    <tool_call>
+    {"name":"func1", "arguments":{...}}
+    </tool_call>
+
+    Tool calls can appear inside <think> sections; the tags are stripped before
+    parsing while preserving the contents.
+    """
+
+    def __init__(self, tokenizer: TokenizerLike):
+        super().__init__(tokenizer)
+        self.prev_tool_call_arr: list[dict] = []
+        self.streamed_args_for_tool: list[str] = []
+        self.current_tool_id = -1
+
+        self.tool_call_start_token = "<tool_call>"
+        self.tool_call_end_token = "</tool_call>"
+        self.think_start_token = "<think>"
+        self.think_end_token = "</think>"
+
+        self.tool_call_regex = re.compile(
+            r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL
+        )
+
+        self._buffer = ""
+        self._think_buffer = ""
+
+    def _strip_think_tags(self, text: str) -> str:
+        return text.replace(self.think_start_token, "").replace(
+            self.think_end_token, ""
+        )
+
+    def _ends_with_partial_token(self, text: str, token: str) -> int:
+        max_len = min(len(text), len(token) - 1)
+        for i in range(max_len, 0, -1):
+            if text.endswith(token[:i]):
+                return i
+        return 0
+
+    def _strip_think_tags_streaming(self, text: str) -> str:
+        if not text:
+            return ""
+        combined = self._think_buffer + text
+        combined = combined.replace(self.think_start_token, "").replace(
+            self.think_end_token, ""
+        )
+        pending_len = max(
+            self._ends_with_partial_token(combined, self.think_start_token),
+            self._ends_with_partial_token(combined, self.think_end_token),
+        )
+        if pending_len:
+            self._think_buffer = combined[-pending_len:]
+            return combined[:-pending_len]
+        self._think_buffer = ""
+        return combined
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        cleaned_output = self._strip_think_tags(model_output)
+        if self.tool_call_start_token not in cleaned_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=cleaned_output
+            )
+
+        try:
+            tool_call_json_list = self.tool_call_regex.findall(cleaned_output)
+            tool_calls = []
+            self.prev_tool_call_arr = []
+            for tool_call_json in tool_call_json_list:
+                tool_call_dict = json.loads(tool_call_json)
+                args_str = json.dumps(
+                    tool_call_dict.get("arguments", {}), ensure_ascii=False
+                )
+                tool_calls.append(
+                    ToolCall(
+                        type="function",
+                        function=FunctionCall(
+                            name=tool_call_dict.get("name", ""),
+                            arguments=args_str,
+                        ),
+                    )
+                )
+                self.prev_tool_call_arr.append(
+                    {"name": tool_call_dict.get("name", ""), "arguments": args_str}
+                )
+
+            content_idx = cleaned_output.find(self.tool_call_start_token)
+            content = cleaned_output[:content_idx].strip()
+            return ExtractedToolCallInformation(
+                tools_called=len(tool_calls) > 0,
+                tool_calls=tool_calls,
+                content=content if content else None,
+            )
+        except Exception:
+            logger.exception("Error in extracting tool call from response.")
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=cleaned_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        if not previous_text:
+            self._buffer = ""
+            self._think_buffer = ""
+            self.prev_tool_call_arr = []
+            self.streamed_args_for_tool = []
+            self.current_tool_id = -1
+
+        cleaned_delta = self._strip_think_tags_streaming(delta_text)
+        if not cleaned_delta and not self._buffer:
+            return None
+
+        self._buffer += cleaned_delta
+
+        start_idx = self._buffer.find(self.tool_call_start_token)
+        if start_idx == -1:
+            partial_len = self._ends_with_partial_token(
+                self._buffer, self.tool_call_start_token
+            )
+            if partial_len:
+                content = self._buffer[:-partial_len]
+                self._buffer = self._buffer[-partial_len:]
+            else:
+                content = self._buffer
+                self._buffer = ""
+            return DeltaMessage(content=content if content else None)
+
+        if start_idx > 0:
+            content = self._buffer[:start_idx]
+            self._buffer = self._buffer[start_idx:]
+            return DeltaMessage(content=content if content else None)
+
+        end_idx = self._buffer.find(self.tool_call_end_token)
+        if end_idx == -1:
+            return None
+
+        full_call_text = self._buffer[: end_idx + len(self.tool_call_end_token)]
+        self._buffer = self._buffer[end_idx + len(self.tool_call_end_token) :]
+
+        match = self.tool_call_regex.search(full_call_text)
+        if not match:
+            logger.warning("Failed to parse tool call block: %s", full_call_text)
+            return None
+
+        try:
+            tool_call_dict = json.loads(match.group(1))
+            args_str = json.dumps(
+                tool_call_dict.get("arguments", {}), ensure_ascii=False
+            )
+        except json.JSONDecodeError:
+            logger.exception("Failed to decode tool call JSON: %s", match.group(1))
+            return None
+
+        if self.current_tool_id == -1:
+            self.current_tool_id = 0
+        tool_index = self.current_tool_id
+        self.current_tool_id += 1
+
+        while len(self.prev_tool_call_arr) <= tool_index:
+            self.prev_tool_call_arr.append({})
+        while len(self.streamed_args_for_tool) <= tool_index:
+            self.streamed_args_for_tool.append("")
+
+        self.prev_tool_call_arr[tool_index] = {
+            "name": tool_call_dict.get("name", ""),
+            "arguments": json.loads(args_str),
+        }
+        self.streamed_args_for_tool[tool_index] = args_str
+
+        return DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=tool_index,
+                    id=make_tool_call_id(),
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name=tool_call_dict.get("name", ""), arguments=args_str
+                    ),
+                )
+            ]
+        )

--- a/vllm/tool_parsers/trinity_tool_parser.py
+++ b/vllm/tool_parsers/trinity_tool_parser.py
@@ -1,31 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import json
 from collections.abc import Sequence
 
-import regex as re
-
-from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import (
-    DeltaFunctionCall,
     DeltaMessage,
-    DeltaToolCall,
     ExtractedToolCallInformation,
-    FunctionCall,
-    ToolCall,
 )
-from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
-from vllm.tool_parsers.abstract_tool_parser import ToolParser
-
-logger = init_logger(__name__)
+from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
 
 
-class TrinityToolParser(ToolParser):
+class TrinityToolParser(Hermes2ProToolParser):
     """
     Tool parser for Trinity models using Qwen-style tool call format:
 
@@ -33,34 +22,24 @@ class TrinityToolParser(ToolParser):
     {"name":"func1", "arguments":{...}}
     </tool_call>
 
-    Tool calls can appear inside <think> sections; the tags are stripped before
-    parsing while preserving the contents.
+    This is essentially a Hermes parser that strips <think>...</think> tags
+    before parsing tool calls.
     """
 
     def __init__(self, tokenizer: TokenizerLike):
         super().__init__(tokenizer)
-        self.prev_tool_call_arr: list[dict] = []
-        self.streamed_args_for_tool: list[str] = []
-        self.current_tool_id = -1
-
-        self.tool_call_start_token = "<tool_call>"
-        self.tool_call_end_token = "</tool_call>"
         self.think_start_token = "<think>"
         self.think_end_token = "</think>"
-
-        self.tool_call_regex = re.compile(
-            r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL
-        )
-
-        self._buffer = ""
         self._think_buffer = ""
 
     def _strip_think_tags(self, text: str) -> str:
+        """Remove think tags from text (non-streaming)."""
         return text.replace(self.think_start_token, "").replace(
             self.think_end_token, ""
         )
 
     def _ends_with_partial_token(self, text: str, token: str) -> int:
+        """Check if text ends with a partial match of token."""
         max_len = min(len(text), len(token) - 1)
         for i in range(max_len, 0, -1):
             if text.endswith(token[:i]):
@@ -68,6 +47,7 @@ class TrinityToolParser(ToolParser):
         return 0
 
     def _strip_think_tags_streaming(self, text: str) -> str:
+        """Remove think tags from text (streaming-aware, handles partial tags)."""
         if not text:
             return ""
         combined = self._think_buffer + text
@@ -89,46 +69,9 @@ class TrinityToolParser(ToolParser):
         model_output: str,
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
+        # Strip think tags before delegating to parent
         cleaned_output = self._strip_think_tags(model_output)
-        if self.tool_call_start_token not in cleaned_output:
-            return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=cleaned_output
-            )
-
-        try:
-            tool_call_json_list = self.tool_call_regex.findall(cleaned_output)
-            tool_calls = []
-            self.prev_tool_call_arr = []
-            for tool_call_json in tool_call_json_list:
-                tool_call_dict = json.loads(tool_call_json)
-                args_str = json.dumps(
-                    tool_call_dict.get("arguments", {}), ensure_ascii=False
-                )
-                tool_calls.append(
-                    ToolCall(
-                        type="function",
-                        function=FunctionCall(
-                            name=tool_call_dict.get("name", ""),
-                            arguments=args_str,
-                        ),
-                    )
-                )
-                self.prev_tool_call_arr.append(
-                    {"name": tool_call_dict.get("name", ""), "arguments": args_str}
-                )
-
-            content_idx = cleaned_output.find(self.tool_call_start_token)
-            content = cleaned_output[:content_idx].strip()
-            return ExtractedToolCallInformation(
-                tools_called=len(tool_calls) > 0,
-                tool_calls=tool_calls,
-                content=content if content else None,
-            )
-        except Exception:
-            logger.exception("Error in extracting tool call from response.")
-            return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=cleaned_output
-            )
+        return super().extract_tool_calls(cleaned_output, request)
 
     def extract_tool_calls_streaming(
         self,
@@ -140,83 +83,21 @@ class TrinityToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
+        # Reset think buffer on first call
         if not previous_text:
-            self._buffer = ""
             self._think_buffer = ""
-            self.prev_tool_call_arr = []
-            self.streamed_args_for_tool = []
-            self.current_tool_id = -1
 
+        # Strip think tags from delta and reconstruct texts
         cleaned_delta = self._strip_think_tags_streaming(delta_text)
-        if not cleaned_delta and not self._buffer:
-            return None
+        cleaned_previous = self._strip_think_tags(previous_text)
+        cleaned_current = cleaned_previous + cleaned_delta
 
-        self._buffer += cleaned_delta
-
-        start_idx = self._buffer.find(self.tool_call_start_token)
-        if start_idx == -1:
-            partial_len = self._ends_with_partial_token(
-                self._buffer, self.tool_call_start_token
-            )
-            if partial_len:
-                content = self._buffer[:-partial_len]
-                self._buffer = self._buffer[-partial_len:]
-            else:
-                content = self._buffer
-                self._buffer = ""
-            return DeltaMessage(content=content if content else None)
-
-        if start_idx > 0:
-            content = self._buffer[:start_idx]
-            self._buffer = self._buffer[start_idx:]
-            return DeltaMessage(content=content if content else None)
-
-        end_idx = self._buffer.find(self.tool_call_end_token)
-        if end_idx == -1:
-            return None
-
-        full_call_text = self._buffer[: end_idx + len(self.tool_call_end_token)]
-        self._buffer = self._buffer[end_idx + len(self.tool_call_end_token) :]
-
-        match = self.tool_call_regex.search(full_call_text)
-        if not match:
-            logger.warning("Failed to parse tool call block: %s", full_call_text)
-            return None
-
-        try:
-            tool_call_dict = json.loads(match.group(1))
-            args_str = json.dumps(
-                tool_call_dict.get("arguments", {}), ensure_ascii=False
-            )
-        except json.JSONDecodeError:
-            logger.exception("Failed to decode tool call JSON: %s", match.group(1))
-            return None
-
-        if self.current_tool_id == -1:
-            self.current_tool_id = 0
-        tool_index = self.current_tool_id
-        self.current_tool_id += 1
-
-        while len(self.prev_tool_call_arr) <= tool_index:
-            self.prev_tool_call_arr.append({})
-        while len(self.streamed_args_for_tool) <= tool_index:
-            self.streamed_args_for_tool.append("")
-
-        self.prev_tool_call_arr[tool_index] = {
-            "name": tool_call_dict.get("name", ""),
-            "arguments": json.loads(args_str),
-        }
-        self.streamed_args_for_tool[tool_index] = args_str
-
-        return DeltaMessage(
-            tool_calls=[
-                DeltaToolCall(
-                    index=tool_index,
-                    id=make_tool_call_id(),
-                    type="function",
-                    function=DeltaFunctionCall(
-                        name=tool_call_dict.get("name", ""), arguments=args_str
-                    ),
-                )
-            ]
+        return super().extract_tool_calls_streaming(
+            cleaned_previous,
+            cleaned_current,
+            cleaned_delta,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+            request,
         )


### PR DESCRIPTION
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 57c7e9375f54613ce39e376086a227197a4c3190. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> **Adds Trinity tool parsing**
> 
> - New `TrinityToolParser` that strips `<think>...</think>` and parses Qwen-style `<tool_call>` JSON; registered via `vllm.tool_parsers` and covered by unit tests (including streaming cases and simple parser tests).
> 
> **XPU communicator enhancements**
> 
> - Supports `allgather_reducescatter` (AgRs) all2all backend with fallback and adds `reduce_scatter`, `reduce_scatterv`, and `all_gatherv` utilities.
> 
> **Multimodal model refactors**
> 
> - Consistently gate initialization using `_mark_language_model`/`_mark_tower_model` across many MM models; simplify `forward` paths by skipping auto-embedding when `intermediate_tensors` is present and removing redundant `get_language_model` overrides; add/adjust placeholder tokens for Ovis/Ovis2.5/PaddleOCR.
> 
> **Testing/util fixes**
> 
> - Correct minimum KV-cache block computation to use ceil division in test utils.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57c7e9375f54613ce39e376086a227197a4c3190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
